### PR TITLE
Add missing property for ingressRef

### DIFF
--- a/deployments/kubernetes/chart/forecastle/crds/forecastleApp.yaml
+++ b/deployments/kubernetes/chart/forecastle/crds/forecastleApp.yaml
@@ -53,6 +53,9 @@ spec:
                 properties:
                   ingressRef:
                     type: object
+                    properties:
+                      name:
+                        type: string
                   routeRef:
                     type: object
                 type: object


### PR DESCRIPTION
Currently the CR for the Forecastle App is not working. This is a fix to the CRD where the property for the name is missing